### PR TITLE
[Autocomplete-Text] Add debounce and fix PropTypes

### DIFF
--- a/src/autocomplete-text/__tests__/autocomplete-text-tests.js
+++ b/src/autocomplete-text/__tests__/autocomplete-text-tests.js
@@ -50,7 +50,7 @@ describe('AutocompleteTextEdit', () => {
                     totalCount: data.length
                 });
             };
-            autocompleteTextEdit = renderIntoDocument(<AutocompleteTextEdit querySearcher={_querySearcher} />);
+            autocompleteTextEdit = renderIntoDocument(<AutocompleteTextEdit onChange={() => console.log('On change call...')} querySearcher={_querySearcher} inputTimeout={0} />);
             inputRef = autocompleteTextEdit.refs.inputText;
             initialState = autocompleteTextEdit.state;
             Simulate.change(inputRef, {target: {value: _query}});
@@ -83,7 +83,7 @@ describe('AutocompleteTextEdit', () => {
             let inputRef;
             let _query = 'test';
             const customError = 'Sorry, no data.'
-            const customQuerySearcher = query => {
+            const _querySearcher = query => {
                 const emptyData = [];
                 return Promise.resolve({
                     emptyData,
@@ -91,7 +91,7 @@ describe('AutocompleteTextEdit', () => {
                 });
             };
             before(() => {
-                autocompleteTextEdit = renderIntoDocument(<AutocompleteTextEdit querySearcher={customQuerySearcher} error={customError} />);
+                autocompleteTextEdit = renderIntoDocument(<AutocompleteTextEdit onChange={() => console.log('On change call...')} querySearcher={_querySearcher} inputTimeout={0} error={customError} />);
                 inputRef = autocompleteTextEdit.refs.inputText;
                 Simulate.change(inputRef, {target: {value: _query}})
             })
@@ -115,7 +115,7 @@ describe('AutocompleteTextEdit', () => {
             });
         };
         before(() => {
-            autocompleteTextEdit = renderIntoDocument(<AutocompleteTextEdit querySearcher={_querySearcher} />);
+            autocompleteTextEdit = renderIntoDocument(<AutocompleteTextEdit onChange={() => console.log('On change call...')} querySearcher={_querySearcher} inputTimeout={0} />);
             inputRef = autocompleteTextEdit.refs.inputText;
             Simulate.change(inputRef, {target: {value: _query}});
         });
@@ -134,7 +134,7 @@ describe('AutocompleteTextEdit', () => {
                     totalCount: data.length
                 });
             };
-            autocompleteTextEdit = renderIntoDocument(<AutocompleteTextEdit querySearcher={_querySearcher} />);
+            autocompleteTextEdit = renderIntoDocument(<AutocompleteTextEdit onChange={() => console.log('On change call...')} querySearcher={_querySearcher} inputTimeout={0} />);
             inputRef = autocompleteTextEdit.refs.inputText;
             initialState = autocompleteTextEdit.state;
             Simulate.change(inputRef, {target: {value: _query}});

--- a/src/autocomplete-text/consult.js
+++ b/src/autocomplete-text/consult.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {PropTypes} from 'react';
 
 function AutocompleteTextConsult({label, name, type, formattedInputValue}) {
     return (

--- a/src/autocomplete-text/edit.js
+++ b/src/autocomplete-text/edit.js
@@ -2,6 +2,7 @@ import React, {Component, PropTypes} from 'react';
 import ReactDOM from 'react-dom';
 import i18next from 'i18next';
 import MDBehaviour from '../behaviours/material';
+import debounce from 'lodash/debounce';
 
 @MDBehaviour('materialInput')
 class AutocompleteTextEdit extends Component {
@@ -22,6 +23,11 @@ class AutocompleteTextEdit extends Component {
             this.setState({error: error});
         }
     }
+
+    componentDidMount() {
+     const {inputTimeout} = this.props;
+     this._debouncedQuerySearcher = debounce(this._querySearcher, inputTimeout);
+   }
 
     // Returns the state's inputValue
     getValue = () =>  {
@@ -63,7 +69,7 @@ class AutocompleteTextEdit extends Component {
         else {
             this.refs.loader.classList.add('mdl-progress__indeterminate');
             this.setState({isLoading: true});
-            this._querySearcher(value);
+            this._debouncedQuerySearcher(value);
             if (onChange) onChange(value);
         }
     };
@@ -106,7 +112,7 @@ class AutocompleteTextEdit extends Component {
     // Maybe give the option for the floating label
     render() {
         const {inputValue, hasSuggestions, hasFocus, isLoading, ...otherProps} = this.state;
-        const {placeholder, showAtFocus, emptyShowAll, error} = this.props
+        const {placeholder, inputTimeout, showAtFocus, emptyShowAll, error} = this.props
         return(
             <div data-focus='autocompleteText'>
                 <div className={`mdl-textfield mdl-js-textfield${error ? ' is-invalid' : ''}`} ref='materialInput'>
@@ -127,10 +133,12 @@ AutocompleteTextEdit.displayName = 'AutocompleteTextEdit';
 AutocompleteTextEdit.defaultProps = {
     placeholder: 'Search here...',
     showAtFocus: false,
-    emptyShowAll: false
+    emptyShowAll: false,
+    inputTimeout: 200
 };
 AutocompleteTextEdit.propTypes = {
     emptyShowAll: PropTypes.bool, //Defines if it shows suggestions on focus when the input is empty.
+    inputTimeout : PropTypes.number.isRequired, //Timeout to execute the debounce function.
     error: PropTypes.string, //Error showed message.
     onChange: PropTypes.func, //Launches the querySearcher.
     placeholder: PropTypes.string, //Placeholder field.


### PR DESCRIPTION
## [Autocomplete-Text] Add debounce and fix PropTypes

### Description

This PR add the changes as they were done on FOCUS Components V2 
https://github.com/KleeGroup/focus-components/commit/d853b9cfc302467e466f8137802661af5f93f424

It also fix the bad calling on the autocomplete-text consult.js file

> Fixes #17