### PR TITLE
[select-mdl] Fix select-mdl values

### DIFF
--- a/src/select-mdl/index.js
+++ b/src/select-mdl/index.js
@@ -74,10 +74,10 @@ class Select extends PureComponent {
     * @override
     */
     render() {
-        const { autoFocus, error, labelKey, name, placeholder, style, rawInputValue, valueKey, disabled, onChange, size, valid } = this.props;
+        const { autoFocus, error, labelKey, name, placeholder, style, rawInputValue, valueKey, disabled, onChange, size, valid, unSelectedLabel } = this.props;
         const selectProps = { autoFocus, disabled, size };
         const currentValue = find(this.props.values, (o) => o[valueKey] === rawInputValue);
-        const currentLabel = (isUndefined(currentValue) || isNull(currentValue)) ? i18next.t('input.select.noLabel') : currentValue[labelKey];
+        const currentLabel = isUndefined(currentValue) || isNull(currentValue) ? i18next.t(unSelectedLabel) : currentValue[labelKey];
         return (
             <div data-focus='select-mdl' ref='select' className='mdl-textfield mdl-js-textfield getmdl-select' data-valid={!error} style={style}>
                 <input placeholder={placeholder} className='mdl-textfield__input' value={currentLabel} type='text' id={name} name={name} readOnly tabIndex='-1' data-val={rawInputValue} ref='htmlSelect' {...selectProps} />

--- a/src/select-mdl/index.js
+++ b/src/select-mdl/index.js
@@ -30,8 +30,8 @@ function _valueParser(propsValue, rawValue) {
 class Select extends PureComponent {
 
     componentDidMount() {
-      const selectMenu = ReactDOM.findDOMNode(this.refs["selectMenu"]);
-      componentHandler.upgradeElement(selectMenu);
+        const selectMenu = ReactDOM.findDOMNode(this.refs["selectMenu"]);
+        componentHandler.upgradeElement(selectMenu);
     }
 
     /**
@@ -56,8 +56,7 @@ class Select extends PureComponent {
 
     /** inheritdoc */
     _renderOptions({hasUndefined, labelKey, isRequired, rawInputValue, values = [], valueKey, isActiveProperty, unSelectedLabel}) {
-        const isRequiredAndNoValue = isRequired && (isUndefined(rawInputValue) || isNull(rawInputValue));
-        values = (hasUndefined || isRequiredAndNoValue) ? union([{[labelKey]: i18next.t(unSelectedLabel), [valueKey]: UNSELECTED_KEY}], this.props.values) : values;
+        values = hasUndefined ? union([{[labelKey]: i18next.t(unSelectedLabel), [valueKey]: UNSELECTED_KEY}], this.props.values) : values;
 
         return values.filter(v => isUndefined(v[isActiveProperty]) || v[isActiveProperty] === true) // Filter on the active value only
         .map((val, idx) => {

--- a/src/select-mdl/index.js
+++ b/src/select-mdl/index.js
@@ -28,12 +28,6 @@ function _valueParser(propsValue, rawValue) {
 * https://github.com/CreativeIT/getmdl-select/
 */
 class Select extends PureComponent {
-    constructor(props) {
-        super(props);
-        const {hasUndefined, isRequired, labelKey, rawInputValue, values = [], valueKey, unSelectedLabel} = props;
-        const isRequiredAndNoValue = isRequired && (isUndefined(rawInputValue) || isNull(rawInputValue));
-        this.allValues = hasUndefined || isRequiredAndNoValue ? union([{[labelKey]: i18next.t(unSelectedLabel), [valueKey]: UNSELECTED_KEY}], values) : values;
-    };
 
     componentDidMount() {
       const selectMenu = ReactDOM.findDOMNode(this.refs["selectMenu"]);
@@ -62,14 +56,16 @@ class Select extends PureComponent {
 
     /** inheritdoc */
     _renderOptions({hasUndefined, labelKey, isRequired, rawInputValue, values = [], valueKey, isActiveProperty, unSelectedLabel}) {
-        return this.allValues.filter(v => isUndefined(v[isActiveProperty]) || v[isActiveProperty] === true) // Filter on the active value only
+        const isRequiredAndNoValue = isRequired && (isUndefined(rawInputValue) || isNull(rawInputValue));
+        values = (hasUndefined || isRequiredAndNoValue) ? union([{[labelKey]: i18next.t(unSelectedLabel), [valueKey]: UNSELECTED_KEY}], this.props.values) : values;
+
+        return values.filter(v => isUndefined(v[isActiveProperty]) || v[isActiveProperty] === true) // Filter on the active value only
         .map((val, idx) => {
             const optVal = `${val[valueKey]}`;
             const elementValue = val[labelKey];
-            const optLabel = isUndefined(elementValue) || isNull(elementValue) ? i18next.t('input.select.noLabel') : elementValue;
             const isSelected = optVal === rawInputValue;
             return (
-                <li key={idx} className='mdl-menu__item' data-selected={isSelected} data-val={optVal} onClick={() => this._handleSelectChange(optVal)}>{optLabel}</li>
+                <li key={idx} className='mdl-menu__item' data-selected={isSelected} data-val={optVal} onClick={() => this._handleSelectChange(optVal)}>{elementValue}</li>
             );
         });
     }
@@ -81,8 +77,8 @@ class Select extends PureComponent {
     render() {
         const { autoFocus, error, labelKey, name, placeholder, style, rawInputValue, valueKey, disabled, onChange, size, valid } = this.props;
         const selectProps = { autoFocus, disabled, size };
-        const currentValue = find(this.allValues, (o) => o[valueKey] === rawInputValue);
-        const currentLabel = isUndefined(currentValue) || isNull(currentValue) ? i18next.t('input.select.noLabel') : currentValue[labelKey];
+        const currentValue = find(this.props.values, (o) => o[valueKey] === rawInputValue);
+        const currentLabel = (isUndefined(currentValue) || isNull(currentValue)) ? i18next.t('input.select.noLabel') : currentValue[labelKey];
         return (
             <div data-focus='select-mdl' ref='select' className='mdl-textfield mdl-js-textfield getmdl-select' data-valid={!error} style={style}>
                 <input placeholder={placeholder} className='mdl-textfield__input' value={currentLabel} type='text' id={name} name={name} readOnly tabIndex='-1' data-val={rawInputValue} ref='htmlSelect' {...selectProps} />

--- a/src/select/index.js
+++ b/src/select/index.js
@@ -72,6 +72,7 @@ class Select extends PureComponent {
     render() {
         const { autoFocus, error, multiple, name, placeholder, style, rawInputValue, values, disabled, onChange, size, valid } = this.props;
         const selectProps = { autoFocus, disabled, multiple, size };
+        console.log(this.props);
         return (
             <div data-focus='select' ref='select' data-valid={!error} style={style}>
                 <select name={name} onChange={this._handleSelectChange} ref='htmlSelect' value={rawInputValue} {...selectProps}>

--- a/src/select/index.js
+++ b/src/select/index.js
@@ -72,7 +72,6 @@ class Select extends PureComponent {
     render() {
         const { autoFocus, error, multiple, name, placeholder, style, rawInputValue, values, disabled, onChange, size, valid } = this.props;
         const selectProps = { autoFocus, disabled, multiple, size };
-        console.log(this.props);
         return (
             <div data-focus='select' ref='select' data-valid={!error} style={style}>
                 <select name={name} onChange={this._handleSelectChange} ref='htmlSelect' value={rawInputValue} {...selectProps}>


### PR DESCRIPTION
## [WIP] [select-mdl] Fix select-mdl values

### Description

This update fix the fact the component doesn't get the given datas in the options. 
I have additionally updated the props which were never used (allValues for example) from the constructor.

I have a problem, when i click in an option, the menu doesn't hide. I have checked, the div with `mdl-menu__container is-upgraded` have a `is-visible` class which should be removed by mdl when we click on the option element which is an `li`.
It only has the good behaviour when we click on an undefined option.

I don't really where it is from mdl or react/redux @TomGallon @Ephrame 

> Fixes #24 