### PR TITLE
Fix [data-valid] on Select

### DIFF
--- a/src/input-textarea/index.js
+++ b/src/input-textarea/index.js
@@ -49,7 +49,7 @@ class InputTextarea extends PureComponent {
         const inputProps =  { autoFocus, disabled, onBlur, onKeyPress, maxLength, onFocus, onClick, id: name, onChange: this._handleInputChange, pattern, size, type, value };
         const mdlClasses = `mdl-textfield mdl-js-textfield${!valid ? ' is-invalid' : ''}`;
         return (
-            <div data-error={!!error} data-focus='input-textarea'>
+            <div data-error={!valid} data-focus='input-textarea'>
                 <div className={mdlClasses} ref='inputTextarea' style={style}>
                     <textarea className='mdl-textfield__input' ref='htmlInput' {...inputProps} />
                     <label className='mdl-textfield__label' htmlFor={name}>{i18next.t(placeholder)}</label>
@@ -78,10 +78,10 @@ InputTextarea.propTypes = {
     minLength: PropTypes.number,
     maxLength: PropTypes.number,
     name: PropTypes.string.isRequired,
-    onBlur: PropTypes.func.isRequired,
+    onBlur: PropTypes.func,
     onChange: PropTypes.func.isRequired,
-    onFocus: PropTypes.func.isRequired,
-    onClick: PropTypes.func.isRequired,
+    onFocus: PropTypes.func,
+    onClick: PropTypes.func,
     onKeyPress: PropTypes.func,
     placeholder: PropTypes.string,
     rawInputValue: PropTypes.oneOfType([

--- a/src/select/index.js
+++ b/src/select/index.js
@@ -73,7 +73,7 @@ class Select extends PureComponent {
         const { autoFocus, error, multiple, name, placeholder, style, rawInputValue, values, disabled, onChange, size, valid } = this.props;
         const selectProps = { autoFocus, disabled, multiple, size };
         return (
-            <div data-focus='select' ref='select' data-valid={!error} style={style}>
+            <div data-focus='select' ref='select' data-valid={valid} style={style}>
                 <select name={name} onChange={this._handleSelectChange} ref='htmlSelect' value={rawInputValue} {...selectProps}>
                     {this._renderOptions(this.props)}
                 </select>


### PR DESCRIPTION
Since `error` has a default value, `!error` was always false and the select was always marked as having an error.
