### PR TITLE
add confirm on close modal. fixes #72. correct translation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "focus-components",
-  "version": "3.0.2-beta1",
+  "version": "3.1.0-rc3",
   "description": "Focus web components to build applications (based on Material Design)",
   "main": "index.js",
   "scripts": {

--- a/src/autocomplete-select/index.js
+++ b/src/autocomplete-select/index.js
@@ -26,7 +26,7 @@ class AutocompleteSelectField extends Component {
     };
 
     _handleAutocompleteBadInput = formattedInputValue => {
-        this.setState({customError: i18next.t('input.autocomplete.error.invalid', {formattedInputValue})})
+        this.setState({customError: i18next.t('focus.components.input.autocomplete.error.invalid', {formattedInputValue})})
     };
 
     _handleAutocompleteChange = rawInputValue => {

--- a/src/button-back/index.js
+++ b/src/button-back/index.js
@@ -7,7 +7,7 @@ function ButtonBack({back}) {
         <Button
             handleOnClick={back}
             icon='keyboard_backspace'
-            label='button.back'
+            label='focus.components.button.back'
             shape={null}
             type='button'
         />

--- a/src/button-help/index.js
+++ b/src/button-help/index.js
@@ -16,7 +16,7 @@ function ButtonHelp({blockName}) {
             className='help-button'
             handleOnClick={() => openHelpCenter(url, blockName)}
             icon='help_outline'
-            label={`${i18next.t('button.help.alt')} : ${blockName}`}
+            label={`${i18next.t('focus.components.button.help')} : ${blockName}`}
             shape='icon'
             type='button'
         />

--- a/src/confirmation-popin/README.md
+++ b/src/confirmation-popin/README.md
@@ -1,0 +1,21 @@
+
+```javascript
+import React, {PureComponent} from 'react';
+import {connect as conntectToConfirm} from 'focus-application/behaviours/confirm';
+import Modal from 'focus-components/modal';
+
+class Home extends PureComponent {
+    render() {
+        const {confirm} = this.props;
+        return (
+            <div data-demo='home-view'>
+                <Modal confirmFunction={confirm}>
+                    <div>test</div>
+                </Modal>
+            </div>
+        );
+    }
+};
+const HomeExtended = conntectToConfirm(Home);
+export default HomeExtended;
+```

--- a/src/confirmation-popin/index.js
+++ b/src/confirmation-popin/index.js
@@ -55,10 +55,15 @@ class ConfirmationModal extends Component {
         return (
             <div data-focus='confirmation-modal'>
                 <Modal onModalClose={this._handleModalClose} open={this.props.open} ref='modal'>
-                    {this.props.children}
-                    <div data-focus='button-stack'>
+                    <div data-focus='confirmation-modal--title'>
+                        <h1>{i18next.t('focus.components.modal.confirmation.title')}</h1>
+                    </div>
+                    <div data-focus='confirmation-modal--content'>
+                        {this.props.children}
+                    </div>
+                    <div data-focus='confirmation-modal--actions'>
                         <Button handleOnClick={this._handleCancel} label={i18next.t(this.props.cancelButtonLabel)} />
-                        <Button handleOnClick={this._handleConfirm} label={i18next.t(this.props.confirmButtonLabel)} option='primary' />
+                        <Button handleOnClick={this._handleConfirm} label={i18next.t(this.props.confirmButtonLabel)} color='primary' />
                     </div>
                 </Modal>
             </div>
@@ -75,7 +80,7 @@ ConfirmationModal.propTypes = {
 };
 ConfirmationModal.defaultProps = {
     open: false,
-    cancelButtonLabel: 'modal.confirmation.cancel',
-    confirmButtonLabel: 'modal.confirmation.confirm'
+    cancelButtonLabel: 'focus.components.modal.confirmation.cancel',
+    confirmButtonLabel: 'focus.components.modal.confirmation.confirm'
 };
 export default ConfirmationModal;

--- a/src/confirmation-popin/index.scss
+++ b/src/confirmation-popin/index.scss
@@ -1,12 +1,22 @@
-[data-focus='confirmation-popin'] {
-  [data-focus='button-stack'] {
-    text-align: center;
-    position: absolute;
-    bottom: 0;
-    width: 100%;
-
-    button {
-      margin: 20px;
+[data-focus='confirmation-modal'] {
+    [data-focus='modal'][data-type='full'][data-size='medium'] > div > [data-focus='modal-window'] {
+        min-width: 500px;
+        min-height: auto;
     }
-  }
+    [data-focus='confirmation-modal--title'] {
+        h1 {
+            font-size: 28px;
+        }
+    }
+    [data-focus='confirmation-modal--content'] {
+        padding: 20px 0;
+    }
+    [data-focus='confirmation-modal--actions'] {
+        text-align: center;
+        width: 100%;
+        padding: 5px 0;
+        button {
+            margin: 0 10px;
+        }
+    }
 }

--- a/src/input-date/index.js
+++ b/src/input-date/index.js
@@ -124,12 +124,12 @@ class InputDate extends Component {
         if ('' === inputDate || !inputDate) {
             return ({
                 isValid: !isRequired,
-                message: 'field.required'
+                message: 'focus.components.field.required'
             });
         } else {
             return ({
                 isValid: this._isInputFormatCorrect(inputDate),
-                message: i18next.t('input.date.invalid', {date: inputDate})
+                message: i18next.t('focus.components.input.date.invalid', {date: inputDate})
             });
         }
     };
@@ -178,7 +178,7 @@ InputDate.propTypes =  {
 };
 InputDate.defaultProps =  {
     drops: 'down',
-    error: 'input.date.error.default',
+    error: 'focus.components.input.date.error.default',
     locale: 'en',
     format: 'MM/DD/YYYY',
     beforeValueGetter: value => value,

--- a/src/input-display/checkbox/index.js
+++ b/src/input-display/checkbox/index.js
@@ -4,7 +4,7 @@ import i18next from 'i18next';
 
 function InputDisplayCheckbox({className, name, rawInputValue}) {
     const stringValue = rawInputValue ? 'true' : 'false';
-    return <div data-focus='input-display-checkbox' className={className} id={name} name={name}>{i18next.t(`input.display.checkbox.${stringValue}`)}</div>
+    return <div data-focus='input-display-checkbox' className={className} id={name} name={name}>{i18next.t(`focus.components.input.display.checkbox.${stringValue}`)}</div>
 }
 
 InputDisplayCheckbox.displayName = 'InputDisplayCheckbox';

--- a/src/panel/edit-save-buttons.js
+++ b/src/panel/edit-save-buttons.js
@@ -4,17 +4,17 @@ import Button from '../button';
 const renderEditingButtons = (toggleEdit, getUserInput, save) => (
     <span>
         <div data-focus='panel-save-action'>
-            <Button icon='save' label='button.save' onClick={() => save(getUserInput())} shape={null} type='button' />
+            <Button icon='save' label='focus.components.button.save' onClick={() => save(getUserInput())} shape={null} type='button' />
         </div>
         <div data-focus='panel-cancel-action'>
-            <Button icon='undo' label='button.cancel' onClick={() => toggleEdit(false)} shape={null} type='button' />
+            <Button icon='undo' label='focus.components.button.cancel' onClick={() => toggleEdit(false)} shape={null} type='button' />
         </div>
     </span>
 );
 
 
 const renderConsultingButtons = (toggleEdit) => (
-    <Button icon='edit' label='button.edit' onClick={() => toggleEdit(true)} shape={null} type='button' />
+    <Button icon='edit' label='focus.components.button.edit' onClick={() => toggleEdit(true)} shape={null} type='button' />
 );
 
 /**

--- a/src/select/index.js
+++ b/src/select/index.js
@@ -60,7 +60,7 @@ class Select extends PureComponent {
         .map((val, idx) => {
             const optVal = `${val[valueKey]}`;
             const elementValue = val[labelKey];
-            const optLabel = isUndefined(elementValue) || isNull(elementValue) ? i18next.t('input.select.noLabel') : elementValue;
+            const optLabel = isUndefined(elementValue) || isNull(elementValue) ? i18next.t('focus.components.input.select.noLabel') : elementValue;
             return (<option key={idx} value={optVal} selected={val.isDefaultValue}>{optLabel}</option>);
         });
     }
@@ -108,7 +108,7 @@ Select.propTypes = {
 };
 Select.defaultProps = {
     disabled: false,
-    error: 'input.select.error.default',
+    error: 'focus.components.input.select.error.default',
     hasUndefined: true,
     isActiveProperty: 'isActive',
     isRequired: false,

--- a/src/translation/resources/fr-FR.js
+++ b/src/translation/resources/fr-FR.js
@@ -1,35 +1,50 @@
 
 export default {
-    button:{
-        cancel: 'Annuler',
-        edit: 'Modifier',
-        help: {
-            at: 'Accédez au centre d\'aide en cliquant ici'
-        },
-        save: 'Enregistrer'
-    },
-    display: {
-        checkbox: {
-            true: 'Oui',
-            false: 'Non'
-        }
-    },
-    field: {
-        required: 'Ce champ est requis'
-    },
-    input: {
-        autocomplete: {
-            error: {
-                invalid: 'Saisie incorrecte'
+    focus: {
+        components: {
+            button: {
+                back: 'Retour',
+                cancel: 'Annuler',
+                edit: 'Modifier',
+                help: 'Accédez au centre d\'aide en cliquant ici',
+                save: 'Enregistrer'
+            },
+            field: {
+                required: 'Ce champ est requis'
+            },
+            modal: {
+                confirmation: {
+                    cancel: 'Abandonner',
+                    confirm: 'Continuer',
+                    text: 'Vous êtes sur le point de quitter la fenêtre. Toutes vos modifications seront perdues. Souhaitez-vous continuer ?',
+                    title: 'Confirmation'
+                }
+            },
+            input: {
+                autocomplete: {
+                    error: {
+                        invalid: 'Saisie incorrecte'
+                    }
+                },
+                display: {
+                    checkbox: {
+                        true: 'Oui',
+                        false: 'Non'
+                    }
+                },
+                date: {
+                    error: {
+                        default: 'Saisie incorrecte'
+                    },
+                    invalid: 'Format {{date}} non valide'
+                },
+                select: {
+                    error: {
+                        default: 'Saisie non valide'
+                    },
+                    noLabel: '-'
+                }
             }
-        },
-        date: {
-            error: {
-                invalid: 'Saisie incorrecte'
-            }
-        },
-        select: {
-            noLabel: 'Aucun label'
         }
     }
 };


### PR DESCRIPTION
# Modal 

## confirm
Add the possibilty to define a confirm action on close button.

![image](https://cloud.githubusercontent.com/assets/5349745/22205456/396a2424-e177-11e6-932e-150e2597f3d5.png)

## Modal props
Change the way `modal` props is defined to a better understand : from `true` to `false`.