### PR TITLE
[Autocomplete-Select] Updating the onBlur and keyDown functions

### DIFF
--- a/src/autocomplete-select/edit.js
+++ b/src/autocomplete-select/edit.js
@@ -101,15 +101,18 @@ class Autocomplete extends Component {
         }
     };
     _handleQueryBlur = () => {
+        const {onChange, onBadInput} = this.props;
         if(this.state.suggestions.length === 1){
-            const {onChange} = this.props;
             this.setState({selected: this.state.suggestions[0].key, focus: false, inputValue: this.state.suggestions[0].label}, () => {
                 if(onChange) onChange(this.state.suggestions[0].key);
             });
         } else {
-            const {onChange} = this.props;
+            const {inputValue} = this.state;
             this.setState({focus: false,}, () => {
                 if(onChange) onChange(null);
+                if (onBadInput && this.getValue() === null && inputValue !== '') {
+                    onBadInput(inputValue);
+                }
             });
         }
     };

--- a/src/autocomplete-select/edit.js
+++ b/src/autocomplete-select/edit.js
@@ -231,7 +231,7 @@ class Autocomplete extends Component {
                         value={inputValue === undefined || inputValue === null ? '' : inputValue}
                     />
                     <label className='mdl-textfield__label'>{i18next.t(placeholder)}</label>
-                    <span className='mdl-textfield__error'>{i18next.t(customError)}</span>
+                    {customError && <span className='mdl-textfield__error'>{i18next.t(customError)}</span>}
                 </div>
                 {renderOptions ? renderOptions.call(this) : this._renderOptions()}
             </div>

--- a/src/autocomplete-select/edit.js
+++ b/src/autocomplete-select/edit.js
@@ -102,7 +102,15 @@ class Autocomplete extends Component {
     };
     _handleQueryBlur = () => {
         if(this.state.suggestions.length === 1){
-          this.setState({inputValue: this.state.suggestions[0].label})
+            const {onChange} = this.props;
+            this.setState({selected: this.state.suggestions[0].key, focus: false, inputValue: this.state.suggestions[0].label}, () => {
+                if(onChange) onChange(this.state.suggestions[0].key);
+            });
+        } else {
+            const {onChange} = this.props;
+            this.setState({focus: false,}, () => {
+                if(onChange) onChange(null);
+            });
         }
     };
     _handleQueryChange = ({target: {value}}) => {
@@ -141,7 +149,10 @@ class Autocomplete extends Component {
         const {which} = event;
         const {active, options} = this.state;
         if (which === ENTER_KEY_CODE && active) this._select(active);
-        if (which === TAB_KEY_CODE) this.setState({focus: false}, () => this.refs.htmlInput.blur());
+        if (which === TAB_KEY_CODE) {
+            this.setState({focus: false});
+            this.refs.htmlInput.blur();
+        }
         if ([DOWN_ARROW_KEY_CODE, UP_ARROW_KEY_CODE].indexOf(which) !== -1) { // the user pressed on an arrow key, change the active key
             const optionKeys = [];
             for (let key of options.keys()) {


### PR DESCRIPTION
## [Autocomplete-Select] Updating the onBlur and keyDown functions

### Description

The Autocomplete-Select now manage correctly the selection on one suggestion on the onBlur or on the tab key down

> Fixes #41 