### PR TITLE
[AutocompleteSelect] Fixing onBlur executing before onClick on suggestions

### DIFF
--- a/src/autocomplete-select/edit.js
+++ b/src/autocomplete-select/edit.js
@@ -197,7 +197,7 @@ class Autocomplete extends Component {
                 data-active={isActive}
                 data-focus='option'
                 key={key}
-                onClick={this._select.bind(this, key)}
+                onMouseDown={this._select.bind(this, key)}
                 onMouseOver={this._handleSuggestionHover.bind(this, key)}
                 >
                 {i18next.t(value)}


### PR DESCRIPTION
## [AutocompleteSelect] Fixing onBlur executing before onClick on suggestions

### Description

Fixing the fact the onBlur was executing before the on click when we select a value.