### PR TITLE
[AutocompleteSelect] Fixing click propagation

### DIFF
--- a/src/autocomplete-select/edit.js
+++ b/src/autocomplete-select/edit.js
@@ -161,7 +161,7 @@ class Autocomplete extends Component {
     };
 
     _handleQueryFocus = () => {
-        this.refs.options.scrollTop = 0;
+        (this.refs.options || {}).scrollTop = 0;
         if (this.props.onFocus) {
             this.props.onFocus.call(this);
         }
@@ -229,9 +229,7 @@ class Autocomplete extends Component {
             );
         }
         return (
-            <ul data-focus='options' ref='options' data-focussed={focus}>
-                {renderedOptions}
-            </ul>
+            focus && <ul data-focus='options' ref='options'> {renderedOptions} </ul>
         );
     };
 

--- a/src/modal/index.scss
+++ b/src/modal/index.scss
@@ -18,6 +18,7 @@ $fill-height-modal-margin: 200px;
     // Full modal type
     @if $type == 'full' {
       min-width: #{$width}vw;
+      min-height: #{$width}vh;
     }
 
     // From menu modal type

--- a/src/modal/index.scss
+++ b/src/modal/index.scss
@@ -18,7 +18,6 @@ $fill-height-modal-margin: 200px;
     // Full modal type
     @if $type == 'full' {
       min-width: #{$width}vw;
-      min-height: #{$width}vh;
     }
 
     // From menu modal type

--- a/src/select-mdl/index.js
+++ b/src/select-mdl/index.js
@@ -82,7 +82,6 @@ class Select extends PureComponent {
         const currentLabel = rawInputValue ? i18next.t(currentValue[labelKey]) : i18next.t(unSelectedLabel)
         const currentDataVal = rawInputValue ? i18next.t(currentValue[labelKey]) : i18next.t(unSelectedLabel)
         const cssClass = `mdl-textfield mdl-js-textfield${!valid ? ' is-invalid' : ''}`;
-        console.log(index);
         return (
             <div data-focus='select-mdl' ref='select' className={`${cssClass} getmdl-select`} data-valid={!error} style={style}>
                 <input placeholder={placeholder} className='mdl-textfield__input' value={currentLabel} type='text' id={index ? `${name}${index}`:`${name}`} name={index ? `${name}${index}`:`${name}`} readOnly tabIndex={index} data-val={currentDataVal} ref='htmlSelect' {...selectProps} />


### PR DESCRIPTION
## [AutocompleteSelect] Fixing click propagation

### Description

Case : when an autocomplete is in a modal, then we click on a option but the option exceed the modal size it closed this modal.

> Fixes #110 #109 